### PR TITLE
Use accurate default header name for JWT assertion

### DIFF
--- a/includes/class-ahjwtauthadmin.php
+++ b/includes/class-ahjwtauthadmin.php
@@ -135,7 +135,7 @@ class AhJwtAuthAdmin {
 			array(
 				'type' => 'string',
 				'show_in_rest' => true,
-				'default' => 'Authorization',
+				'default' => 'Cf-Access-Jwt-Assertion',
 			),
 		);
 


### PR DESCRIPTION
The new value is the default header name that is injected into a request by CF Zero Trust.

https://developers.cloudflare.com/cloudflare-one/identity/authorization-cookie/validating-json/

The previous value (`Authorization`) is not applicable anywhere to the extent of my knowledge, thus it makes no sense to keep it as the default value.

For existing users of this plugin, this should not have any negative impact, because nobody will have it working properly without setting a custom value for the header name.

If this approach is subpar, then maybe it makes sense to rather remove the default value entirely.