### PR TITLE
Register a missing setting to allow saving default role

### DIFF
--- a/includes/class-ahjwtauthadmin.php
+++ b/includes/class-ahjwtauthadmin.php
@@ -139,6 +139,16 @@ class AhJwtAuthAdmin {
 			),
 		);
 
+		register_setting(
+			'ahjwtauth-sign-in-widget',
+			'ahjwtauth-user-role',
+			array(
+				'type' => 'string',
+				'show_in_rest' => true,
+				'default' => 'subscriber'
+			),
+		);
+
 		add_settings_field(
 			'ahjwtauth-private-secret',
 			'JWT Private Secret',


### PR DESCRIPTION
Default role is not changeable because the setting was not registered. It just shows up on the UI, changing it reverts it to the previous value.

This change allows the default role to be saved.

Fixes #10 #12 