### PR TITLE
Add support to validate aud token claim

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -1,6 +1,8 @@
 /.wordpress-org
 /.git
 /.github
+/tests
+/kahlan-config.php
 
 .distignore
 .gitignore

--- a/README.md
+++ b/README.md
@@ -10,11 +10,13 @@ This plugin assumes that it can retrieve a valid JWT from a configured HTTP head
 
 * The plugin retrieves the user id (email) from the JWT and then checks if such a user exists. If not, the plugin creates a new user by using this email and signs him/her in.
 * If a `role` claim is included in the JWT this will be assigned to the user.
+* If a JWT audience is configured in the plugin settings, the JWT must include a matching `aud` claim.
 * The plugin expects the JWT is passed as a HTTP header (default is `Authorization`). For example, the payload of JWT may look like:  
 
 ```json
 {
   "email": "admin@example.com",
+  "aud": "example-oauth-client-id",
   "role": "admin"
 }
 ```

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,11 @@
 {
     "require": {
         "firebase/php-jwt": "^6.2"
+    },
+    "scripts": {
+        "test": "php tests/run-kahlan.php"
+    },
+    "require-dev": {
+        "kahlan/kahlan": "^5.2"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2bdb41da111a542da33262e827f3137b",
+    "content-hash": "d6ebf75393672fcbab30715d83ac4373",
     "packages": [
         {
             "name": "firebase/php-jwt",
@@ -70,13 +70,73 @@
             "time": "2023-12-01T16:26:39+00:00"
         }
     ],
-    "packages-dev": [],
+    "packages-dev": [
+        {
+            "name": "kahlan/kahlan",
+            "version": "5.2.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/kahlan/kahlan.git",
+                "reference": "8a403d35bd564a2a315a7c4544e73827ef56c540"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/kahlan/kahlan/zipball/8a403d35bd564a2a315a7c4544e73827ef56c540",
+                "reference": "8a403d35bd564a2a315a7c4544e73827ef56c540",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "rector/rector": "^1.1.1",
+                "squizlabs/php_codesniffer": "^3.10.1"
+            },
+            "bin": [
+                "bin/kahlan"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Kahlan\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "CrysaLEAD"
+                }
+            ],
+            "description": "The PHP Test Framework for Freedom, Truth and Justice.",
+            "keywords": [
+                "BDD",
+                "Behavior-Driven Development",
+                "Monkey Patching",
+                "TDD",
+                "mock",
+                "stub",
+                "testing",
+                "unit test"
+            ],
+            "support": {
+                "issues": "https://github.com/kahlan/kahlan/issues",
+                "source": "https://github.com/kahlan/kahlan/tree/5.2.8"
+            },
+            "time": "2024-10-18T19:01:44+00:00"
+        }
+    ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": [],
+    "platform": {},
+    "platform-dev": {},
     "plugin-api-version": "2.6.0"
 }

--- a/includes/class-ahjwtauthadmin.php
+++ b/includes/class-ahjwtauthadmin.php
@@ -141,6 +141,17 @@ class AhJwtAuthAdmin {
 
 		register_setting(
 			'ahjwtauth-sign-in-widget',
+			'ahjwtauth-audience',
+			array(
+				'type' => 'string',
+				'show_in_rest' => true,
+				'sanitize_callback' => 'sanitize_text_field',
+				'default' => '',
+			),
+		);
+
+		register_setting(
+			'ahjwtauth-sign-in-widget',
 			'ahjwtauth-user-role',
 			array(
 				'type' => 'string',
@@ -188,6 +199,21 @@ class AhJwtAuthAdmin {
 					'text',
 					__( 'Enter the HTTP header that contains the JWT.', 'ah-jwt-auth' ),
 					__( 'The JWT will be retrieved from the specified HTTP header. This defaults to the "Authorization" header.', 'ah-jwt-auth' ),
+				);
+			},
+			'ahjwtauth-sign-in-widget',
+			'ahjwtauth-sign-in-widget-options-section',
+		);
+
+		add_settings_field(
+			'ahjwtauth-audience',
+			'JWT Audience',
+			function() {
+				$this->options_page_text_input_action(
+					'ahjwtauth-audience',
+					'text',
+					__( 'Enter the expected aud claim value.', 'ah-jwt-auth' ),
+					__( 'If set, incoming JWTs must include a matching aud claim. Leave empty to disable audience validation.', 'ah-jwt-auth' ),
 				);
 			},
 			'ahjwtauth-sign-in-widget',

--- a/includes/class-ahjwtauthsignin.php
+++ b/includes/class-ahjwtauthsignin.php
@@ -26,6 +26,27 @@ use Firebase\JWT\Key;
  */
 class AhJwtAuthSignIn {
 	/**
+	 * Admin handler.
+	 *
+	 * @var AhJwtAuthAdmin
+	 */
+	private $ah_jwt_auth_admin;
+
+	/**
+	 * Error message to display in admin notices.
+	 *
+	 * @var string
+	 */
+	private $error;
+
+	/**
+	 * Warning message to display in admin notices.
+	 *
+	 * @var string
+	 */
+	private $warning;
+
+	/**
 	 * Sets up the class ready for use
 	 *
 	 * @return void
@@ -345,10 +366,40 @@ class AhJwtAuthSignIn {
 	 */
 	private function get_alg() {
 		$jwks_url = get_option( 'ahjwtauth-jwks-url' );
-		if ( '' === $jwks_url ) {
+		if ( '' !== $jwks_url ) {
+			return 'RS256';
+		}
+
+		if ( $this->is_public_key( get_option( 'ahjwtauth-private-secret' ) ) ) {
 			return 'RS256';
 		}
 
 		return 'HS256';
+	}
+
+	/**
+	 * Determines whether the configured key material is a public key.
+	 *
+	 * @param string $key_material the configured key material.
+	 * @return bool true if the key material is a public key
+	 */
+	private function is_public_key( $key_material ) {
+		if ( ! is_string( $key_material ) || '' === trim( $key_material ) ) {
+			return false;
+		}
+
+		if ( function_exists( 'openssl_pkey_get_public' ) ) {
+			$public_key = @openssl_pkey_get_public( $key_material );
+			if ( false !== $public_key ) {
+				if ( is_resource( $public_key ) ) {
+					openssl_free_key( $public_key );
+				}
+				return true;
+			}
+
+			return false;
+		}
+
+		return 1 === preg_match( '/-----BEGIN (PUBLIC KEY|RSA PUBLIC KEY|CERTIFICATE)-----/', $key_material );
 	}
 }

--- a/includes/class-ahjwtauthsignin.php
+++ b/includes/class-ahjwtauthsignin.php
@@ -249,7 +249,48 @@ class AhJwtAuthSignIn {
 		} catch ( Exception $e ) {
 			return false;
 		}
+		if ( ! $this->validate_audience( $payload ) ) {
+			return false;
+		}
 		return $payload;
+	}
+
+	/**
+	 * Validates the JWT audience claim against the configured audience value.
+	 *
+	 * If no audience value has been configured, audience validation is skipped
+	 * to maintain backwards compatibility with existing installations.
+	 *
+	 * @param object $payload the payload from the JWT.
+	 * @return bool true if the audience is valid or validation is disabled
+	 */
+	private function validate_audience( $payload ) {
+		$expected_audience = trim( get_option( 'ahjwtauth-audience', '' ) );
+		if ( '' === $expected_audience ) {
+			return true;
+		}
+
+		if ( ! isset( $payload->aud ) ) {
+			$this->error = __( 'AH JWT Auth: The JWT does not contain the required aud claim.', 'ah-jwt-auth' );
+			error_log( 'AH JWT Auth: ERROR: The JWT does not contain the required aud claim.' );
+			return false;
+		}
+
+		if ( is_string( $payload->aud ) && hash_equals( $expected_audience, $payload->aud ) ) {
+			return true;
+		}
+
+		if ( is_array( $payload->aud ) ) {
+			foreach ( $payload->aud as $audience ) {
+				if ( is_string( $audience ) && hash_equals( $expected_audience, $audience ) ) {
+					return true;
+				}
+			}
+		}
+
+		$this->error = __( 'AH JWT Auth: The JWT aud claim does not match the configured audience.', 'ah-jwt-auth' );
+		error_log( 'AH JWT Auth: ERROR: The JWT aud claim does not match the configured audience.' );
+		return false;
 	}
 
 	/**

--- a/kahlan-config.php
+++ b/kahlan-config.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Kahlan test configuration.
+ *
+ * @package AhJwtAuth
+ */
+
+use Kahlan\Filter\Filters;
+
+Filters::apply(
+	$this,
+	'bootstrap',
+	function( $next ) {
+		require __DIR__ . '/tests/bootstrap.php';
+
+		return $next();
+	}
+);

--- a/readme.txt
+++ b/readme.txt
@@ -18,6 +18,8 @@ that sits in front of your WordPress deployment.
 
 Authentication and optionally role assignment is handled by claims contained in the JWT.
 
+If configured, the plugin also validates the JWT `aud` claim against the expected OAuth2 application audience value.
+
 Verification of the JWT is handled by either:
 
 * a shared secret key
@@ -44,8 +46,11 @@ The JWT must contain at least an `email` claim and may also contain a `role` cla
 
     {
         "email": "admin@example.com",
+        "aud": "example-oauth-client-id",
         "role": "admin"
     }
+
+The `aud` claim is only required when a JWT Audience value has been configured in the plugin settings.
 
 = What signature algorimths are supported to verify the JWT? =
 

--- a/tests/AudienceValidation.spec.php
+++ b/tests/AudienceValidation.spec.php
@@ -1,0 +1,200 @@
+<?php
+/**
+ * Audience validation specs.
+ *
+ * @package AhJwtAuth
+ */
+
+declare(strict_types=1);
+
+use AhJwtAuth\AhJwtAuthSignIn;
+use Firebase\JWT\JWT;
+
+function verify_token_for_test( $configured_audience, $payload, $configured_key = 'test-secret', $signing_key = null, $algorithm = 'HS256' ) {
+	$GLOBALS['ahjwtauth_test_options']['ahjwtauth-audience'] = $configured_audience;
+	$GLOBALS['ahjwtauth_test_options']['ahjwtauth-private-secret'] = $configured_key;
+	$GLOBALS['ahjwtauth_test_options']['ahjwtauth-jwks-url'] = '';
+
+	$jwt = JWT::encode( $payload, null === $signing_key ? $configured_key : $signing_key, $algorithm );
+
+	$reflection = new ReflectionClass( AhJwtAuthSignIn::class );
+	$sign_in = $reflection->newInstanceWithoutConstructor();
+	$method = $reflection->getMethod( 'verify_token' );
+	$method->setAccessible( true );
+
+	return $method->invoke( $sign_in, $jwt );
+}
+
+function rsa_key_pair_for_test() {
+	$private_key = openssl_pkey_new(
+		array(
+			'private_key_bits' => 2048,
+			'private_key_type' => OPENSSL_KEYTYPE_RSA,
+		)
+	);
+	openssl_pkey_export( $private_key, $private_key_pem );
+	$details = openssl_pkey_get_details( $private_key );
+
+	return array(
+		'private' => $private_key_pem,
+		'public' => $details['key'],
+	);
+}
+
+describe(
+	'AhJwtAuthSignIn JWT audience validation',
+	function() {
+		beforeEach(
+			function() {
+				$GLOBALS['ahjwtauth_test_options'] = array();
+			}
+		);
+
+		it(
+			'decodes a signed JWT without checking aud when no audience is configured',
+			function() {
+				$payload = array(
+					'email' => 'admin@example.com',
+				);
+
+				$decoded = verify_token_for_test( '', $payload );
+
+				expect( $decoded )->not->toBe( false );
+				expect( $decoded->email )->toBe( 'admin@example.com' );
+			}
+		);
+
+		it(
+			'decodes a signed JWT with a matching string audience',
+			function() {
+				$payload = array(
+					'email' => 'admin@example.com',
+					'aud' => 'oauth-client-id',
+				);
+
+				$decoded = verify_token_for_test( 'oauth-client-id', $payload );
+
+				expect( $decoded )->not->toBe( false );
+				expect( $decoded->aud )->toBe( 'oauth-client-id' );
+			}
+		);
+
+		it(
+			'decodes an RS256 JWT when the configured key value is a PEM public key',
+			function() {
+				$key_pair = rsa_key_pair_for_test();
+				$payload = array(
+					'email' => 'admin@example.com',
+					'aud' => 'oauth-client-id',
+				);
+
+				$decoded = verify_token_for_test( 'oauth-client-id', $payload, $key_pair['public'], $key_pair['private'], 'RS256' );
+
+				expect( $decoded )->not->toBe( false );
+				expect( $decoded->aud )->toBe( 'oauth-client-id' );
+			}
+		);
+
+		it(
+			'decodes a signed JWT with a matching audience in an array claim',
+			function() {
+				$payload = array(
+					'email' => 'admin@example.com',
+					'aud' => array( 'other-client-id', 'oauth-client-id' ),
+				);
+
+				$decoded = verify_token_for_test( 'oauth-client-id', $payload );
+
+				expect( $decoded )->not->toBe( false );
+				expect( $decoded->aud )->toContain( 'oauth-client-id' );
+			}
+		);
+
+		it(
+			'trims the configured audience before validation',
+			function() {
+				$payload = array(
+					'email' => 'admin@example.com',
+					'aud' => 'oauth-client-id',
+				);
+
+				$decoded = verify_token_for_test( ' oauth-client-id ', $payload );
+
+				expect( $decoded )->not->toBe( false );
+				expect( $decoded->aud )->toBe( 'oauth-client-id' );
+			}
+		);
+
+		it(
+			'rejects a signed JWT when the configured audience is missing from the payload',
+			function() {
+				$payload = array(
+					'email' => 'admin@example.com',
+				);
+
+				expect( verify_token_for_test( 'oauth-client-id', $payload ) )->toBe( false );
+			}
+		);
+
+		it(
+			'rejects a signed JWT with a mismatched string audience',
+			function() {
+				$payload = array(
+					'email' => 'admin@example.com',
+					'aud' => 'wrong-client-id',
+				);
+
+				expect( verify_token_for_test( 'oauth-client-id', $payload ) )->toBe( false );
+			}
+		);
+
+		it(
+			'rejects a signed JWT with a mismatched array audience',
+			function() {
+				$payload = array(
+					'email' => 'admin@example.com',
+					'aud' => array( 'wrong-client-id', 'other-client-id' ),
+				);
+
+				expect( verify_token_for_test( 'oauth-client-id', $payload ) )->toBe( false );
+			}
+		);
+
+		it(
+			'rejects a signed JWT with a non-string audience claim value',
+			function() {
+				$payload = array(
+					'email' => 'admin@example.com',
+					'aud' => 12345,
+				);
+
+				expect( verify_token_for_test( 'oauth-client-id', $payload ) )->toBe( false );
+			}
+		);
+
+		it(
+			'rejects a JWT signed with the wrong secret before audience validation can pass',
+			function() {
+				$GLOBALS['ahjwtauth_test_options']['ahjwtauth-audience'] = 'oauth-client-id';
+				$GLOBALS['ahjwtauth_test_options']['ahjwtauth-private-secret'] = 'expected-secret';
+				$GLOBALS['ahjwtauth_test_options']['ahjwtauth-jwks-url'] = '';
+
+				$jwt = JWT::encode(
+					array(
+						'email' => 'admin@example.com',
+						'aud' => 'oauth-client-id',
+					),
+					'wrong-secret',
+					'HS256'
+				);
+
+				$reflection = new ReflectionClass( AhJwtAuthSignIn::class );
+				$sign_in = $reflection->newInstanceWithoutConstructor();
+				$method = $reflection->getMethod( 'verify_token' );
+				$method->setAccessible( true );
+
+				expect( $method->invoke( $sign_in, $jwt ) )->toBe( false );
+			}
+		);
+	}
+);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Test bootstrap for WordPress function stubs.
+ *
+ * @package AhJwtAuth
+ */
+
+declare(strict_types=1);
+
+error_reporting( E_ALL & ~E_DEPRECATED );
+ini_set( 'log_errors', '1' );
+ini_set( 'error_log', sys_get_temp_dir() . '/ahjwtauth-test-error.log' );
+
+$GLOBALS['ahjwtauth_test_options'] = array();
+
+if ( ! function_exists( 'get_option' ) ) {
+	function get_option( $option_name, $default = false ) {
+		return array_key_exists( $option_name, $GLOBALS['ahjwtauth_test_options'] )
+			? $GLOBALS['ahjwtauth_test_options'][ $option_name ]
+			: $default;
+	}
+}
+
+if ( ! function_exists( '__' ) ) {
+	function __( $text, $domain = 'default' ) {
+		return $text;
+	}
+}
+
+$composer_vendor_dir = getenv( 'COMPOSER_VENDOR_DIR' );
+$autoload = false !== $composer_vendor_dir
+	? $composer_vendor_dir . '/autoload.php'
+	: __DIR__ . '/../vendor/autoload.php';
+
+if ( file_exists( $autoload ) ) {
+	require_once $autoload;
+}
+
+require_once __DIR__ . '/../includes/class-ahjwtauthadmin.php';
+require_once __DIR__ . '/../includes/class-ahjwtauthsignin.php';

--- a/tests/run-kahlan.php
+++ b/tests/run-kahlan.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Cross-platform Kahlan test runner.
+ *
+ * @package AhJwtAuth
+ */
+
+declare(strict_types=1);
+
+$vendor_dir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'ahjwtauth-test-vendor';
+putenv( 'COMPOSER_VENDOR_DIR=' . $vendor_dir );
+$_ENV['COMPOSER_VENDOR_DIR'] = $vendor_dir;
+$_SERVER['COMPOSER_VENDOR_DIR'] = $vendor_dir;
+
+function ahjwtauth_run_command( $command ) {
+	$descriptor_spec = array(
+		0 => STDIN,
+		1 => STDOUT,
+		2 => STDERR,
+	);
+
+	$process = proc_open( $command, $descriptor_spec, $pipes, dirname( __DIR__ ) );
+	if ( ! is_resource( $process ) ) {
+		fwrite( STDERR, 'Unable to start command: ' . $command . PHP_EOL );
+		exit( 1 );
+	}
+
+	$status = proc_close( $process );
+	if ( 0 !== $status ) {
+		exit( $status );
+	}
+}
+
+ahjwtauth_run_command( 'composer install --no-interaction --no-progress' );
+
+$kahlan = $vendor_dir . DIRECTORY_SEPARATOR . 'bin' . DIRECTORY_SEPARATOR . 'kahlan';
+if ( 'Windows' === PHP_OS_FAMILY ) {
+	$kahlan .= '.bat';
+}
+
+ahjwtauth_run_command( escapeshellarg( $kahlan ) . ' --spec=tests' );


### PR DESCRIPTION
Without validating the audience (aud) token claim, this may be a bit of a security issue if the tokens are issued for multiple OAuth2 applications that use the same signing keys. This is typical for issuers that use signing keys per tenant (like Cloudflare Teams or auth0 tenants).

The consequence of not validating this claim allows using a token signed for an application to sign in into a different application from the same tenant even when the access policy may not allow this. Combined with auto account creation, this can have really suboptimal results. This is problematic if multiple WordPress blogs sit behind a common issuer which is precisely my use case.

This token claim validation allows to uniquely identify which application the token was signed for so the access policies are honoured.

To make sure that the implementation is correct, wrapped up a test suite. Since there was none, the testing uses Kahlan as testing framework as it doesn't require ext-dom, unlike PHPUnit, so this works out of the box on simpler PHP installations.

It also contains a fix for get_alg() as functionally it was always returning RS256. This came up upon invoking the test suite.

When using the JWKS endpoint,  Firebase JWT uses the parsed JWKS key metadata, so get_alg() returns a mostly documentary value as this function isn't called. This means that the HS256 branch was never hit. The fix implements value parsing for the shared secret and it uses the following flow: PEM encoded value -> RS256, everything else -> HS256. If the OpenSSL extension is not available in the PHP installation, it does a graceful fallback to string parsing.