### PR TITLE
Add option to disable automatic user creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This plugin assumes that it can retrieve a valid JWT from a configured HTTP head
 
 ## How it works
 
-* The plugin retrieves the user id (email) from the JWT and then checks if such a user exists. If not, the plugin creates a new user by using this email and signs him/her in.
+* The plugin retrieves the user id (email) from the JWT and then checks if such a user exists. If not, the plugin creates a new user by using this email and signs him/her in, unless automatic user creation has been disabled in the plugin settings.
 * If a `role` claim is included in the JWT this will be assigned to the user.
 * The plugin expects the JWT is passed as a HTTP header (default is `Authorization`). For example, the payload of JWT may look like:  
 
@@ -26,6 +26,8 @@ Users are created with a random password (64 characters long), which effectively
 During the creation process the user is assigned the configured default role or the role from the "role" claim in the JWT if it was included.
 
 In addition the SSO process will set an existing users role to match the "role" claim in the JWT if it was present.
+
+Automatic user creation can be disabled in the plugin settings. When disabled, a valid JWT only signs in users that already exist in WordPress.
 
 ## Credits
 

--- a/includes/class-ahjwtauthadmin.php
+++ b/includes/class-ahjwtauthadmin.php
@@ -99,6 +99,27 @@ class AhJwtAuthAdmin {
 	}
 
 	/**
+	 * Displays a checkbox input field on the options page
+	 *
+	 * @param string $option_name the name of the plugin option.
+	 * @param string $label the label displayed next to the checkbox.
+	 * @param string $description description to display under option.
+	 * @return void
+	 */
+	public function options_page_checkbox_input_action( $option_name, $label, $description = false ) {
+		$option_value = get_option( $option_name, '0' );
+		printf(
+			'<input type="hidden" name="%1$s" value="0" /><label for="%1$s"><input type="checkbox" id="%1$s" name="%1$s" value="1" %2$s /> %3$s</label>',
+			esc_attr( $option_name ),
+			checked( '1', $option_value, false ),
+			esc_html( $label )
+		);
+		if ( false !== $description ) {
+			echo '<p class="description">' . esc_html( $description ) . '</p>';
+		}
+	}
+
+	/**
 	 * Sets up actions for plugin settings
 	 *
 	 * @return void
@@ -146,6 +167,19 @@ class AhJwtAuthAdmin {
 				'type' => 'string',
 				'show_in_rest' => true,
 				'default' => 'subscriber'
+			),
+		);
+
+		register_setting(
+			'ahjwtauth-sign-in-widget',
+			'ahjwtauth-disable-user-creation',
+			array(
+				'type' => 'string',
+				'show_in_rest' => true,
+				'default' => '0',
+				'sanitize_callback' => function( $value ) {
+					return '1' === $value ? '1' : '0';
+				},
 			),
 		);
 
@@ -201,6 +235,20 @@ class AhJwtAuthAdmin {
 				$this->options_page_select_input_action(
 					'ahjwtauth-user-role',
 					__( 'Select the role for and auto-created user if a role claim is not found in the JWT.', 'ah-jwt-auth' ),
+				);
+			},
+			'ahjwtauth-sign-in-widget',
+			'ahjwtauth-sign-in-widget-options-section',
+		);
+
+		add_settings_field(
+			'ahjwtauth-disable-user-creation',
+			'Automatic User Creation',
+			function() {
+				$this->options_page_checkbox_input_action(
+					'ahjwtauth-disable-user-creation',
+					__( 'Disable automatic user creation', 'ah-jwt-auth' ),
+					__( 'Require users to be manually provisioned before they can sign in with a valid JWT.', 'ah-jwt-auth' ),
 				);
 			},
 			'ahjwtauth-sign-in-widget',

--- a/includes/class-ahjwtauthsignin.php
+++ b/includes/class-ahjwtauthsignin.php
@@ -76,6 +76,12 @@ class AhJwtAuthSignIn {
 		$user = get_user_by( 'email', $email );
 
 		if ( ! $user ) {
+			if ( '1' === get_option( 'ahjwtauth-disable-user-creation', '0' ) ) {
+				$this->error = __( 'AH JWT Auth found a valid JWT, but the user does not exist and automatic user creation is disabled.', 'ah-jwt-auth' );
+				error_log( 'AH JWT Auth: ERROR: valid JWT found, but user does not exist and automatic user creation is disabled.' );
+				return;
+			}
+
 			$random_password = wp_generate_password( 64, false );
 			$user_id = wp_create_user( $email, $random_password, $email );
 			$user = get_user_by( 'id', $user_id );

--- a/readme.txt
+++ b/readme.txt
@@ -23,9 +23,11 @@ Verification of the JWT is handled by either:
 * a shared secret key
 * retrieving a JSON Web Key Set (JWKS) from a configured URL
 
-During the login process if the user does not exist an account will be created with a matching role from the JWT.
+During the login process if the user does not exist an account will be created with a matching role from the JWT, unless automatic user creation has been disabled in the plugin settings.
 
 If the JWT did not contain a role claim then user is created with the role set in the plugin settings (by default this is the subscriber role).
+
+Automatic user creation is enabled by default for backwards compatibility. It can be disabled when user provisioning should remain manual.
 
 == Frequently Asked Questions ==
 


### PR DESCRIPTION
This one is pretty easy. Adds a checkbox to disable automatic user creation so authentication is only permitted if a user has been provisioned in WordPress before authenticating via IdP.

Left as disabled by default for backwards compatibility. It works as compensating control for something like #28, but this feature sits on its own as one may want to keep user provisioning explicit.