### PR TITLE
Add option to verify JWT issuer

### DIFF
--- a/ah-jwt-auth.php
+++ b/ah-jwt-auth.php
@@ -10,7 +10,7 @@
  * @wordpress-plugin
  * Plugin Name: AH JWT Auth
  * Description: This plugin allows sign in to WordPress using a JSON Web Token (JWT) contained in a HTTP Header
- * Version: 2.0.0
+ * Version: 2.1.0
  * Author: Andrew Heberle
  * Text Domain: ah-jwt-auth
  * Author URI: https://github.com/andrewheberle/wordpress-ah-jwt-auth/

--- a/includes/class-ahjwtauthadmin.php
+++ b/includes/class-ahjwtauthadmin.php
@@ -156,6 +156,7 @@ class AhJwtAuthAdmin {
 			array(
 				'type' => 'string',
 				'show_in_rest' => true,
+				'sanitize_callback' => 'sanitize_text_field',
 				'default' => 'Authorization',
 			),
 		);
@@ -163,6 +164,17 @@ class AhJwtAuthAdmin {
 		register_setting(
 			'ahjwtauth-sign-in-widget',
 			'ahjwtauth-audience',
+			array(
+				'type' => 'string',
+				'show_in_rest' => true,
+				'sanitize_callback' => 'sanitize_text_field',
+				'default' => '',
+			),
+		);
+
+		register_setting(
+			'ahjwtauth-sign-in-widget',
+			'ahjwtauth-issuer',
 			array(
 				'type' => 'string',
 				'show_in_rest' => true,
@@ -233,6 +245,21 @@ class AhJwtAuthAdmin {
 					'text',
 					__( 'Enter the HTTP header that contains the JWT.', 'ah-jwt-auth' ),
 					__( 'The JWT will be retrieved from the specified HTTP header. This defaults to the "Authorization" header.', 'ah-jwt-auth' ),
+				);
+			},
+			'ahjwtauth-sign-in-widget',
+			'ahjwtauth-sign-in-widget-options-section',
+		);
+
+		add_settings_field(
+			'ahjwtauth-audience',
+			'JWT Issuer',
+			function () {
+				$this->options_page_text_input_action(
+					'ahjwtauth-audience',
+					'text',
+					__( 'Enter the expected iss claim value.', 'ah-jwt-auth' ),
+					__( 'If set, incoming JWTs must include a matching iss claim. Leave empty to disable issuer validation.', 'ah-jwt-auth' ),
 				);
 			},
 			'ahjwtauth-sign-in-widget',

--- a/includes/class-ahjwtauthadmin.php
+++ b/includes/class-ahjwtauthadmin.php
@@ -252,11 +252,11 @@ class AhJwtAuthAdmin {
 		);
 
 		add_settings_field(
-			'ahjwtauth-audience',
+			'ahjwtauth-issuer',
 			'JWT Issuer',
 			function () {
 				$this->options_page_text_input_action(
-					'ahjwtauth-audience',
+					'ahjwtauth-issuer',
 					'text',
 					__( 'Enter the expected iss claim value.', 'ah-jwt-auth' ),
 					__( 'If set, incoming JWTs must include a matching iss claim. Leave empty to disable issuer validation.', 'ah-jwt-auth' ),

--- a/includes/class-ahjwtauthsignin.php
+++ b/includes/class-ahjwtauthsignin.php
@@ -269,14 +269,32 @@ class AhJwtAuthSignIn {
 		}
 		try {
 			$payload = JWT::decode( $jwt, $key );
+		} catch ( DomainException $e ) {
+			$this->error = __( 'AH JWT Auth: The provided JWT is malformed', 'ah-jwt-auth' );
+			error_log( 'AH JWT Auth: ERROR: The provided JWT is malformed: ' . $e->getMessage() );
+			return false;
+		} catch ( UnexpectedValueException $e ) {
+			$this->error = __( 'AH JWT Auth: The provided JWT was invalid', 'ah-jwt-auth' );
+			error_log( 'AH JWT Auth: ERROR: The provided JWT was invalid: ' . $e->getMessage() );
+			return false;
 		} catch ( SignatureInvalidException $e ) {
-			$this->error = __( 'AH JWT Auth: Cannot verify the JWT. Please double check that your private secret or JWKS URL is configured correctly', 'ah-jwt-auth' );
-			error_log( 'AH JWT Auth: ERROR: Cannot verify the JWT. Please double check that your private secret or JWKS URL is configured correctly' );
+			$this->error = __( 'AH JWT Auth: Cannot verify the signature of the JWT. Please double check that your private secret or JWKS URL is configured correctly', 'ah-jwt-auth' );
+			error_log( 'AH JWT Auth: ERROR: Cannot verify the signature of the JWT. Please double check that your private secret or JWKS URL is configured correctly: ' . $e->getMessage() );
+			return false;
+		} catch ( BeforeValidException $e ) {
+			$this->error = __( 'AH JWT Auth: The provided JWT is trying to be used before it\'s eligible as defined by the \'nbf\' and/or \'iat\' claim', 'ah-jwt-auth' );
+			error_log( 'AH JWT Auth: ERROR: The provided JWT is trying to be used before it\'s eligible as defined by the \'nbf\' and/or \'iat\' claim: ' . $e->getMessage() );
+			return false;
+		} catch ( ExpiredException $e ) {
+			$this->error = __( 'AH JWT Auth: The provided JWT has since expired, as defined by the \'exp\' claim', 'ah-jwt-auth' );
+			error_log( 'AH JWT Auth: ERROR: The provided JWT has since expired, as defined by the \'exp\' claim: ' . $e->getMessage() );
 			return false;
 		} catch ( Exception $e ) {
+			$this->error = __( 'AH JWT Auth: There was an unhandled exception while verifiying the JWT', 'ah-jwt-auth' );
+			error_log( 'AH JWT Auth: ERROR: There was an unhandled exception while verifiying the JWT: ' . $e->getMessage() );
 			return false;
 		}
-		if ( ! $this->validate_audience( $payload ) ) {
+		if ( ! $this->validate_audience( $payload ) || ! $this->validate_issuer( $payload ) ) {
 			return false;
 		}
 		return $payload;
@@ -321,6 +339,35 @@ class AhJwtAuthSignIn {
 	}
 
 	/**
+	 * Validates the JWT issuer (iss) claim against the configured issuer value.
+	 *
+	 * If no issuer value has been configured, issuer validation is skipped.
+	 *
+	 * @param object $payload the payload from the JWT.
+	 * @return bool true if the issuer is valid or validation is disabled
+	 */
+	private function validate_issuer( $payload ) {
+		$expected_issuer = trim( get_option( 'ahjwtauth-issuer', '' ) );
+		if ( '' === $expected_issuer ) {
+			return true;
+		}
+
+		if ( ! isset( $payload->iss ) ) {
+			$this->error = __( 'AH JWT Auth: The JWT does not contain the required iss claim.', 'ah-jwt-auth' );
+			error_log( 'AH JWT Auth: ERROR: The JWT does not contain the required iss claim.' );
+			return false;
+		}
+
+		if ( hash_equals( $expected_issuer, $payload->iss ) ) {
+			return true;
+		}
+
+		$this->error = __( 'AH JWT Auth: The JWT iss claim does not match the configured issuer.', 'ah-jwt-auth' );
+		error_log( 'AH JWT Auth: ERROR: The JWT iss claim does not match the configured issuer.' );
+		return false;
+	}
+
+	/**
 	 * Returns the key to verify the JWT
 	 *
 	 * Depending on the configuration of the plugin, this function will return
@@ -348,6 +395,7 @@ class AhJwtAuthSignIn {
 			return $keys;
 		}
 
+		// throw new Exception( get_option( 'ahjwtauth-private-secret' ) );
 		return new Key( get_option( 'ahjwtauth-private-secret' ), $this->get_alg() );
 	}
 

--- a/includes/class-ahjwtauthsignin.php
+++ b/includes/class-ahjwtauthsignin.php
@@ -395,7 +395,6 @@ class AhJwtAuthSignIn {
 			return $keys;
 		}
 
-		// throw new Exception( get_option( 'ahjwtauth-private-secret' ) );
 		return new Key( get_option( 'ahjwtauth-private-secret' ), $this->get_alg() );
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -9,51 +9,67 @@ Requires PHP: 8.0
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
-This plugin allows sign in to WordPress using a JSON Web Token (JWT) contained in a HTTP Header.
+This plugin allows sign in to WordPress using a JSON Web Token (JWT) contained
+in a HTTP Header.
 
 == Description ==
 
-This plugin allows sign in to WordPress using a JSON Web Token (JWT) contained in a HTTP Header that is added by a reverse proxy
-that sits in front of your WordPress deployment.
+This plugin allows sign in to WordPress using a JSON Web Token (JWT) contained
+in a HTTP Header that is added by a reverse proxy that sits in front of your
+WordPress deployment.
 
-Authentication and optionally role assignment is handled by claims contained in the JWT.
+Authentication and optionally role assignment is handled by claims contained in
+the JWT.
 
-If configured, the plugin also validates the JWT `aud` claim against the expected OAuth2 application audience value.
+If configured, the plugin also validates the JWT `aud` and `iss` claims against
+the expected application audience and JWT issuer values.
 
 Verification of the JWT is handled by either:
 
-* a shared secret for HS256 (as per RFC 7518 this must be at least 256-bits in size)
+* a shared secret for HS256 (as per RFC 7518 this must be at least 256-bits in
+  size)
 * a PEM encoded public key for RS256
 * retrieving a JSON Web Key Set (JWKS) from a configured URL (also for RS256)
 
-During the login process if the user does not exist an account will be created with a matching role from the JWT, unless automatic user creation has been disabled in the plugin settings.
+During the login process if the user does not exist an account will be created
+with a matching role from the JWT, unless automatic user creation has been
+disabled in the plugin settings.
 
-If the JWT did not contain a role claim then user is created with the role set in the plugin settings (by default this is the subscriber role).
+If the JWT did not contain a role claim then user is created with the role set
+in the plugin settings (by default this is the subscriber role).
 
-Automatic user creation is enabled by default for backwards compatibility. It can be disabled when user provisioning should remain manual.
+Automatic user creation is enabled by default for backwards compatibility. It
+can be disabled when user provisioning should remain manual.
 
 == Frequently Asked Questions ==
 
 = What header is the JWT retrieved from? =
 
-By default the plugin looks for the JWT in the `Authorization` header as follows:
+By default the plugin looks for the JWT in the `Authorization` header as
+follows:
 
     Authorization: Bearer <JWT Here>
 
-However the token may be retrieved from a configurable HTTP header, for example integration with Cloudflare Access would use
-the `Cf-Access-Jwt-Assertion` header.
+However the token may be retrieved from a configurable HTTP header, for example
+integration with Cloudflare Access, which was the original target for this
+plugin, you would configure the use of the `Cf-Access-Jwt-Assertion` header.
 
-= What should the JWT contain? =
+= What claims should the JWT contain? =
 
 The JWT must contain at least an `email` claim and may also contain a `role` claim:
 
     {
+        "iss": "example.com",
+        "aud": "example-audience-id",
         "email": "admin@example.com",
-        "aud": "example-oauth-client-id",
+        "iat": 1356999524,
+        "nbf": 1357000000,
         "role": "admin"
     }
 
-The `aud` claim is only required when a JWT Audience value has been configured in the plugin settings.
+The `aud` and `iss` claims are only required when a JWT Audience and/or Issuer
+value has been configured in the plugin settings, however as they are standard
+JWT claims it is recommended to set these options to verify those claims.
 
 = What signature algorimths are supported to verify the JWT? =
 
@@ -61,12 +77,17 @@ Currently only the HS256 and RS256 alorithms are supported.
 
 == Screenshots ==
 
-1. This example shows a configuration with a WordPress install behind Cloudflare Access for SSO via JWT
+1. This example shows a configuration with a WordPress install behind
+   Cloudflare Access for SSO via JWT
 
 == Changelog ==
 
+= 2.1.0 =
+* Add option to verify JWT issuer
+
 = 2.0.0 =
-* **Breaking Change:** Any secrets that are less than 256-bytes (32-characters) in length will fail JWT HS256 verification
+* **Breaking Change:** Any secrets that are less than 256-bytes (32-characters)
+  in length will fail JWT HS256 verification
 
 = 1.6.0 =
 * Added option to verify JWT Audience (AUD)

--- a/tests/JwtValidation.spec.php
+++ b/tests/JwtValidation.spec.php
@@ -15,7 +15,7 @@ function verify_token_for_test( $configured_audience, $payload, $configured_key 
 	$GLOBALS['ahjwtauth_test_options']['ahjwtauth-private-secret'] = $configured_key;
 	$GLOBALS['ahjwtauth_test_options']['ahjwtauth-jwks-url'] = '';
 
-	$jwt = JWT::encode( $payload, null === $signing_key ? str_pad( $configured_key, 32, "\0" ) : $signing_key, $algorithm );
+	$jwt = JWT::encode( $payload, null === $signing_key ? $configured_key : $signing_key, $algorithm );
 
 	$reflection = new ReflectionClass( AhJwtAuthSignIn::class );
 	$sign_in = $reflection->newInstanceWithoutConstructor();
@@ -40,6 +40,153 @@ function rsa_key_pair_for_test() {
 		'public' => $details['key'],
 	);
 }
+
+describe(
+	'AhJwtAuthSignIn Basic JWT validation',
+	function() {
+		beforeEach(
+			function() {
+				$GLOBALS['ahjwtauth_test_options'] = array();
+			}
+		);
+	
+		it(
+			'decodes a minimal signed JWT',
+			function() {
+				$payload = array(
+					'email' => 'admin@example.com',
+				);
+
+				$decoded = verify_token_for_test( '', $payload );
+
+				expect( $decoded )->not->toBe( false );
+				expect( $decoded->email )->toBe( 'admin@example.com' );
+			}
+		);
+
+		it(
+			'decodes a JWT with all full set of claims',
+			function() {
+				$iat = time() - 240;
+				$payload = array(
+					'iss' => 'example.com',
+					'email' => 'admin@example.com',
+					'aud' => 'oauth-client-id',
+					'iat' => $iat,
+					'nbf' => $iat,
+					'exp' => $iat + 480,
+				);
+
+				$decoded = verify_token_for_test( 'oauth-client-id', $payload );
+
+				expect( $decoded )->not->toBe( false );
+				expect( $decoded->iss )->toBe( 'example.com' );
+				expect( $decoded->email )->toBe( 'admin@example.com' );
+				expect( $decoded->aud )->toBe( 'oauth-client-id' );
+			}
+		);
+
+		it(
+			'rejects an expired JWT',
+			function() {
+				$iat = time() - 240;
+				$payload = array(
+					'iss' => 'example.com',
+					'email' => 'admin@example.com',
+					'aud' => 'oauth-client-id',
+					'iat' => $iat,
+					'nbf' => $iat,
+					'exp' => $iat + 120,
+				);
+
+				$decoded = verify_token_for_test( 'oauth-client-id', $payload );
+
+				expect( $decoded )->toBe( false );
+			}
+		);
+
+		it(
+			'rejects a JWT issued in the future',
+			function() {
+				$iat = time() + 240;
+				$payload = array(
+					'iss' => 'example.com',
+					'email' => 'admin@example.com',
+					'aud' => 'oauth-client-id',
+					'iat' => $iat,
+					'nbf' => $iat,
+					'exp' => $iat + 120,
+				);
+
+				$decoded = verify_token_for_test( 'oauth-client-id', $payload );
+
+				expect( $decoded )->toBe( false );
+			}
+		);
+
+		it(
+			'rejects a JWT that is not yet valid',
+			function() {
+				$iat = time() - 60;
+				$payload = array(
+					'iss' => 'example.com',
+					'email' => 'admin@example.com',
+					'aud' => 'oauth-client-id',
+					'iat' => $iat,
+					'nbf' => $iat + 120,
+					'exp' => $iat + 480,
+				);
+
+				$decoded = verify_token_for_test( 'oauth-client-id', $payload );
+
+				expect( $decoded )->toBe( false );
+			}
+		);
+
+		it(
+			'accepts a JWT that is has the correct issuer',
+			function() {
+				$GLOBALS['ahjwtauth_test_options']['ahjwtauth-issuer'] = 'example.com';
+				$iat = time() - 60;
+				$payload = array(
+					'iss' => 'example.com',
+					'email' => 'admin@example.com',
+					'aud' => 'oauth-client-id',
+					'iat' => $iat,
+					'nbf' => $iat,
+					'exp' => $iat + 480,
+				);
+
+				$decoded = verify_token_for_test( 'oauth-client-id', $payload );
+
+				expect( $decoded )->not->toBe( false );
+				expect( $decoded->iss )->toBe( 'example.com' );
+				expect( $decoded->email )->toBe( 'admin@example.com' );
+				expect( $decoded->aud )->toBe( 'oauth-client-id' );
+			}
+		);
+
+		it(
+			'rejects a JWT that is has the incorrect issuer',
+			function() {
+				$GLOBALS['ahjwtauth_test_options']['ahjwtauth-issuer'] = 'example.org';
+				$iat = time() - 60;
+				$payload = array(
+					'iss' => 'example.com',
+					'email' => 'admin@example.com',
+					'aud' => 'oauth-client-id',
+					'iat' => $iat,
+					'nbf' => $iat,
+					'exp' => $iat + 480,
+				);
+
+				$decoded = verify_token_for_test( 'oauth-client-id', $payload );
+
+				expect( $decoded )->toBe( false );
+			}
+		);
+	}
+);
 
 describe(
 	'AhJwtAuthSignIn JWT audience validation',
@@ -176,7 +323,7 @@ describe(
 			'rejects a JWT signed with the wrong secret before audience validation can pass',
 			function() {
 				$GLOBALS['ahjwtauth_test_options']['ahjwtauth-audience'] = 'oauth-client-id';
-				$GLOBALS['ahjwtauth_test_options']['ahjwtauth-private-secret'] = 'expected-secret';
+				$GLOBALS['ahjwtauth_test_options']['ahjwtauth-private-secret'] = 'the-expected-secret-at-least-256-bits-long';
 				$GLOBALS['ahjwtauth_test_options']['ahjwtauth-jwks-url'] = '';
 
 				$jwt = JWT::encode(


### PR DESCRIPTION
This PR adds the option to verify the issuer of the provided JWT.

To maintain backwards compatibility this is only verified if the option is set.