### PR TITLE
Code review

### DIFF
--- a/ah-jwt-auth.php
+++ b/ah-jwt-auth.php
@@ -10,7 +10,7 @@
  * @wordpress-plugin
  * Plugin Name: AH JWT Auth
  * Description: This plugin allows sign in to WordPress using a JSON Web Token (JWT) contained in a HTTP Header
- * Version: 2.1.0
+ * Version: 2.2.0
  * Author: Andrew Heberle
  * Text Domain: ah-jwt-auth
  * Author URI: https://github.com/andrewheberle/wordpress-ah-jwt-auth/
@@ -35,8 +35,12 @@
 
 namespace AhJwtAuth;
 
-require 'vendor/autoload.php';
-require 'includes/class-ahjwtauthsignin.php';
-require 'includes/class-ahjwtauthadmin.php';
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
 
-$ah_jwt_auth = new AhJwtAuthSignIn();
+require_once plugin_dir_path( __FILE__ ) . 'vendor/autoload.php';
+require_once plugin_dir_path( __FILE__ ) . 'includes/class-ahjwtauthsignin.php';
+require_once plugin_dir_path( __FILE__ ) . 'includes/class-ahjwtauthadmin.php';
+
+new AhJwtAuthSignIn();

--- a/ah-jwt-auth.php
+++ b/ah-jwt-auth.php
@@ -36,7 +36,7 @@
 namespace AhJwtAuth;
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 require_once plugin_dir_path( __FILE__ ) . 'vendor/autoload.php';

--- a/includes/class-ahjwtauthadmin.php
+++ b/includes/class-ahjwtauthadmin.php
@@ -10,9 +10,13 @@
 
 namespace AhJwtAuth;
 
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
 /**
  *
- * This class handles the settings/admin sie of the plugin to
+ * This class handles the settings/admin side of the plugin to
  * allow configuration of the plugin.
  *
  * @category Class
@@ -138,6 +142,7 @@ class AhJwtAuthAdmin {
 			array(
 				'type' => 'string',
 				'show_in_rest' => false,
+				'sanitize_callback' => 'sanitize_textarea_field',
 			),
 		);
 
@@ -147,6 +152,7 @@ class AhJwtAuthAdmin {
 			array(
 				'type' => 'string',
 				'show_in_rest' => true,
+				'sanitize_callback' => 'esc_url_raw',
 			),
 		);
 
@@ -189,6 +195,13 @@ class AhJwtAuthAdmin {
 			array(
 				'type' => 'string',
 				'show_in_rest' => true,
+				'sanitize_callback' => function ( $value ) {
+					$valid_roles = wp_roles()->get_names();
+					if ( array_key_exists( $value, $valid_roles ) ) {
+						return $value;
+					}
+					return 'subscriber';
+				},
 				'default' => 'subscriber',
 			),
 		);
@@ -229,7 +242,7 @@ class AhJwtAuthAdmin {
 					'ahjwtauth-jwks-url',
 					'text',
 					__( 'Enter the JWKS URL to validate the JWT.', 'ah-jwt-auth' ),
-					__( 'The retreived JWKS is used for verifying the token (use this field or the "JWT Private Secret", not both)', 'ah-jwt-auth' ),
+					__( 'The retrieved JWKS is used for verifying the token (use this field or the "JWT Private Secret", not both)', 'ah-jwt-auth' ),
 				);
 			},
 			'ahjwtauth-sign-in-widget',
@@ -287,7 +300,7 @@ class AhJwtAuthAdmin {
 			function () {
 				$this->options_page_select_input_action(
 					'ahjwtauth-user-role',
-					__( 'Select the role for and auto-created user if a role claim is not found in the JWT.', 'ah-jwt-auth' ),
+					__( 'Select the role for an auto-created user if a role claim is not found in the JWT.', 'ah-jwt-auth' ),
 				);
 			},
 			'ahjwtauth-sign-in-widget',

--- a/includes/class-ahjwtauthadmin.php
+++ b/includes/class-ahjwtauthadmin.php
@@ -40,8 +40,8 @@ class AhJwtAuthAdmin {
 	 */
 	public function options_menu_action() {
 		add_options_page(
-			'AH JWT Auth Options',
-			'AH JWT Auth',
+			__( 'AH JWT Auth Options', 'ah-jwt-auth' ),
+			__( 'AH JWT Auth', 'ah-jwt-auth' ),
 			'manage_options',
 			'ahjwtauth-sign-in-widget',
 			array( $this, 'options_page_action' )
@@ -57,7 +57,7 @@ class AhJwtAuthAdmin {
 		if ( current_user_can( 'manage_options' ) ) {
 			include plugin_dir_path( __FILE__ ) . '../templates/options-form.php';
 		} else {
-			wp_die( 'You do not have sufficient permissions to access this page.' );
+			wp_die( __( 'You do not have sufficient permissions to access this page.', 'ah-jwt-auth' ) );
 		}
 	}
 
@@ -219,6 +219,19 @@ class AhJwtAuthAdmin {
 			),
 		);
 
+		register_setting(
+			'ahjwtauth-sign-in-widget',
+			'ahjwtauth-fail-closed',
+			array(
+				'type' => 'string',
+				'show_in_rest' => true,
+				'default' => '0', // Default to 0 (Fail-Open) for backwards compatibility
+				'sanitize_callback' => function ( $value ) {
+					return '1' === $value ? '1' : '0';
+				},
+			),
+		);
+
 		add_settings_field(
 			'ahjwtauth-private-secret',
 			'JWT Private Secret',
@@ -315,6 +328,20 @@ class AhJwtAuthAdmin {
 					'ahjwtauth-disable-user-creation',
 					__( 'Disable automatic user creation', 'ah-jwt-auth' ),
 					__( 'Require users to be manually provisioned before they can sign in with a valid JWT.', 'ah-jwt-auth' ),
+				);
+			},
+			'ahjwtauth-sign-in-widget',
+			'ahjwtauth-sign-in-widget-options-section',
+		);
+
+		add_settings_field(
+			'ahjwtauth-fail-closed',
+			'Enforce Strict Auth (Fail-Closed)',
+			function () {
+				$this->options_page_checkbox_input_action(
+					'ahjwtauth-fail-closed',
+					__( 'Enable strict Fail-Closed mode', 'ah-jwt-auth' ),
+					__( 'Require a valid JWT for all unauthenticated traffic. If a token is invalid, expired, or entirely missing, block access immediately.', 'ah-jwt-auth' ),
 				);
 			},
 			'ahjwtauth-sign-in-widget',

--- a/includes/class-ahjwtauthadmin.php
+++ b/includes/class-ahjwtauthadmin.php
@@ -11,7 +11,7 @@
 namespace AhJwtAuth;
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 /**
@@ -57,7 +57,7 @@ class AhJwtAuthAdmin {
 		if ( current_user_can( 'manage_options' ) ) {
 			include plugin_dir_path( __FILE__ ) . '../templates/options-form.php';
 		} else {
-			wp_die( __( 'You do not have sufficient permissions to access this page.', 'ah-jwt-auth' ) );
+			wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'ah-jwt-auth' ) );
 		}
 	}
 
@@ -225,7 +225,7 @@ class AhJwtAuthAdmin {
 			array(
 				'type' => 'string',
 				'show_in_rest' => true,
-				'default' => '0', // Default to 0 (Fail-Open) for backwards compatibility
+				'default' => '0',
 				'sanitize_callback' => function ( $value ) {
 					return '1' === $value ? '1' : '0';
 				},

--- a/includes/class-ahjwtauthsignin.php
+++ b/includes/class-ahjwtauthsignin.php
@@ -64,7 +64,7 @@ class AhJwtAuthSignIn {
 		$this->ah_jwt_auth_admin = new AhJwtAuthAdmin();
 
 		add_action( 'admin_notices', array( $this, 'ahjwtauth_admin_notice' ) );
-		add_action( 'login_head', array( $this, 'ahjwtauth_log_user_in' ) );
+		add_action( 'init', array( $this, 'ahjwtauth_log_user_in' ) );
 		add_action( 'admin_init', array( $this, 'ahjwtauth_schedule_fetch_jwks' ) );
 		add_action( 'ahjwtauth_fetch_jwks', array( $this, 'ahjwtauth_fetch_jwks' ) );
 	}
@@ -83,20 +83,57 @@ class AhJwtAuthSignIn {
 			return;
 		}
 
+		// Allow background tasks (WP-Cron, WP-CLI) to bypass JWT checks.
+		if ( defined( 'DOING_CRON' ) && DOING_CRON ) {
+			return;
+		}
+		if ( defined( 'WP_CLI' ) && WP_CLI ) {
+			return;
+		}
+
+		$fail_closed = '1' === get_option( 'ahjwtauth-fail-closed', '0' );
+
 		// get jwt.
 		$jwt = $this->get_token();
 		if ( false === $jwt ) {
+			// If Fail-Closed is enabled, enforce the token requirement strictly.
+			if ( $fail_closed ) {
+				wp_die( 
+					esc_html__( 'Access Denied: This site requires a valid JWT.', 'ah-jwt-auth' ), 
+					esc_html__( 'JWT Authentication Required', 'ah-jwt-auth' ), 
+					array( 'response' => 401 ) 
+				);
+			}
+
 			return;
 		}
 
 		// verify JWT and grab payload.
 		$payload = $this->verify_token( $jwt );
 		if ( false === $payload ) {
+			// Check if the administrator explicitly enabled Fail-Closed enforcement.
+			if ( $fail_closed ) {
+				wp_die( 
+					esc_html__( 'Authentication failed: The provided JWT is invalid or expired.', 'ah-jwt-auth' ), 
+					esc_html__( 'JWT Authentication Error', 'ah-jwt-auth' ), 
+					array( 'response' => 401 ) 
+				);
+			}
+			
 			return;
 		}
 
 		// If we cannot extract the user's email from header this is an error.
 		if ( ! isset( $payload->email ) ) {
+			// Check if the administrator explicitly enabled Fail-Closed enforcement.
+			if ( $fail_closed ) {
+				wp_die( 
+					esc_html__( 'Authentication failed: The provided JWT did not include an email claim.', 'ah-jwt-auth' ), 
+					esc_html__( 'JWT Authentication Error', 'ah-jwt-auth' ), 
+					array( 'response' => 401 ) 
+				);
+			}
+			
 			$this->error = __( 'AH JWT Auth expects email attribute to identify user, but it does not exist in the JWT. Please check your reverse proxy configuration', 'ah-jwt-auth' );
 			return;
 		}
@@ -106,6 +143,15 @@ class AhJwtAuthSignIn {
 
 		if ( ! $user ) {
 			if ( '1' === get_option( 'ahjwtauth-disable-user-creation', '0' ) ) {
+				// Check if the administrator explicitly enabled Fail-Closed enforcement.
+				if ( $fail_closed ) {
+					wp_die( 
+						esc_html__( 'Authentication failed: No account exists for this JWT.', 'ah-jwt-auth' ), 
+						esc_html__( 'JWT Authentication Error', 'ah-jwt-auth' ), 
+						array( 'response' => 401 ) 
+					);
+				}
+				
 				$this->error = __( 'AH JWT Auth found a valid JWT, but the user does not exist and automatic user creation is disabled.', 'ah-jwt-auth' );
 				error_log( 'AH JWT Auth: ERROR: valid JWT found, but user does not exist and automatic user creation is disabled.' );
 				return;
@@ -140,6 +186,7 @@ class AhJwtAuthSignIn {
 			$redirect_url = admin_url();
 		}
 		$redirect_to = isset( $_GET['redirect_to'] ) ? esc_url_raw( wp_unslash( $_GET['redirect_to'] ) ) : $redirect_url;
+
 		wp_safe_redirect( $redirect_to );
 		exit;
 	}
@@ -152,16 +199,19 @@ class AhJwtAuthSignIn {
 	 * @return void
 	 */
 	public function ahjwtauth_admin_notice() {
-		if ( isset( $this->error ) ) {
-			$class = 'notice notice-error';
-			$message = $this->error;
-			printf( '<div class="%1$s"><p>%2$s</p></div>', esc_attr( $class ), esc_html( $message ) );
-		}
+		// Only print admin notices to administrative users.
+		if ( current_user_can( 'manage_options' ) ) {
+			if ( isset( $this->error ) ) {
+				$class = 'notice notice-error';
+				$message = $this->error;
+				printf( '<div class="%1$s"><p>%2$s</p></div>', esc_attr( $class ), esc_html( $message ) );
+			}
 
-		if ( isset( $this->warning ) ) {
-			$class = 'notice notice-warning is-dismissible';
-			$message = $this->warning;
-			printf( '<div class="%1$s"><p>%2$s</p></div>', esc_attr( $class ), esc_html( $message ) );
+			if ( isset( $this->warning ) ) {
+				$class = 'notice notice-warning is-dismissible';
+				$message = $this->warning;
+				printf( '<div class="%1$s"><p>%2$s</p></div>', esc_attr( $class ), esc_html( $message ) );
+			}
 		}
 	}
 
@@ -248,15 +298,18 @@ class AhJwtAuthSignIn {
 	 * @return string the payload from the JWT
 	 */
 	private function get_token() {
-		$jwt_header = $this->get_header();
-		if ( ! isset( $_SERVER[ $jwt_header ] ) ) {
-			$this->warning = __( 'AH JWT Auth the expected JWT was not found. Please double check your reverse proxy configuration.', 'ah-jwt-auth' );
-			error_log( 'AH JWT Auth: WARNING: the expected JWT was not found. Please double check your reverse proxy configuration.' );
+		$request_headers = getallheaders();
+		$normalized_headers = array_change_key_case( $request_headers, CASE_LOWER );
+		$target_header = strtolower( get_option( 'ahjwtauth-jwt-header', 'Authorization' ) );
+		
+		if ( ! isset( $normalized_headers[ $target_header ] ) ) {
+			$this->warning = __( 'AH JWT Auth: The expected JWT was not found. Please double check your reverse proxy configuration.', 'ah-jwt-auth' );
+			error_log( 'AH JWT Auth: WARNING: The expected JWT was not found.' );
 			return false;
 		}
 
-		// Handle "Header: Bearer <JWT>" form by stripping the "Bearer " prefix.
-		$array = explode( ' ', wp_unslash( $_SERVER[ $jwt_header ] ) );
+		$raw_header_value = wp_unslash( $normalized_headers[ $target_header ] );
+		$array = explode( ' ', $raw_header_value );
 		if ( 'Bearer' === $array[0] ) {
 			array_shift( $array );
 		}
@@ -395,30 +448,23 @@ class AhJwtAuthSignIn {
 		if ( '' !== $jwks_url ) {
 			$jwks = $this->ahjwtauth_fetch_jwks();
 
+			if ( ! is_array( $jwks ) || ! isset( $jwks['keys'] ) ) {
+				$this->error = __( 'AH JWT Auth: Invalid or missing keys in JWKS response.', 'ah-jwt-auth' );
+				error_log( 'AH JWT Auth: ERROR: Invalid or missing keys in JWKS response.' );
+				return false;
+			}
+
 			try {
 				$keys = JWK::parseKeySet( array( 'keys' => $jwks['keys'] ) );
+				return $keys;
 			} catch ( Exception $e ) {
 				$this->error = $e->getMessage();
 				error_log( 'AH JWT Auth: ERROR: Problem parsing key-set: ' . $e->getMessage() );
 				return false;
 			}
-
-			return $keys;
 		}
 
 		return new Key( get_option( 'ahjwtauth-private-secret' ), $this->get_alg() );
-	}
-
-	/**
-	 * Returns a header in "HTTP" form into a form usable with $_SERVER['HEADER']
-	 *
-	 * The returned string is done by converting the configured setting to uppercase,
-	 * replacing "-" with "_" and adding the prefix of "HTTP_".
-	 *
-	 * @return string the header name usable with _$SERVER
-	 */
-	private function get_header() {
-		return 'HTTP_' . str_replace( '-', '_', strtoupper( get_option( 'ahjwtauth-jwt-header' ) ) );
 	}
 
 	/**

--- a/includes/class-ahjwtauthsignin.php
+++ b/includes/class-ahjwtauthsignin.php
@@ -11,7 +11,7 @@
 namespace AhJwtAuth;
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 use DomainException;
@@ -98,10 +98,10 @@ class AhJwtAuthSignIn {
 		if ( false === $jwt ) {
 			// If Fail-Closed is enabled, enforce the token requirement strictly.
 			if ( $fail_closed ) {
-				wp_die( 
-					esc_html__( 'Access Denied: This site requires a valid JWT.', 'ah-jwt-auth' ), 
-					esc_html__( 'JWT Authentication Required', 'ah-jwt-auth' ), 
-					array( 'response' => 401 ) 
+				wp_die(
+					esc_html__( 'Access Denied: This site requires a valid JWT.', 'ah-jwt-auth' ),
+					esc_html__( 'JWT Authentication Required', 'ah-jwt-auth' ),
+					array( 'response' => 401 )
 				);
 			}
 
@@ -113,10 +113,10 @@ class AhJwtAuthSignIn {
 		if ( false === $payload ) {
 			// Check if the administrator explicitly enabled Fail-Closed enforcement.
 			if ( $fail_closed ) {
-				wp_die( 
-					esc_html__( 'Authentication failed: The provided JWT is invalid or expired.', 'ah-jwt-auth' ), 
-					esc_html__( 'JWT Authentication Error', 'ah-jwt-auth' ), 
-					array( 'response' => 401 ) 
+				wp_die(
+					esc_html__( 'Authentication failed: The provided JWT is invalid or expired.', 'ah-jwt-auth' ),
+					esc_html__( 'JWT Authentication Error', 'ah-jwt-auth' ),
+					array( 'response' => 401 )
 				);
 			}
 			
@@ -127,10 +127,10 @@ class AhJwtAuthSignIn {
 		if ( ! isset( $payload->email ) ) {
 			// Check if the administrator explicitly enabled Fail-Closed enforcement.
 			if ( $fail_closed ) {
-				wp_die( 
-					esc_html__( 'Authentication failed: The provided JWT did not include an email claim.', 'ah-jwt-auth' ), 
-					esc_html__( 'JWT Authentication Error', 'ah-jwt-auth' ), 
-					array( 'response' => 401 ) 
+				wp_die(
+					esc_html__( 'Authentication failed: The provided JWT did not include an email claim.', 'ah-jwt-auth' ),
+					esc_html__( 'JWT Authentication Error', 'ah-jwt-auth' ),
+					array( 'response' => 401 )
 				);
 			}
 			
@@ -145,10 +145,10 @@ class AhJwtAuthSignIn {
 			if ( '1' === get_option( 'ahjwtauth-disable-user-creation', '0' ) ) {
 				// Check if the administrator explicitly enabled Fail-Closed enforcement.
 				if ( $fail_closed ) {
-					wp_die( 
-						esc_html__( 'Authentication failed: No account exists for this JWT.', 'ah-jwt-auth' ), 
-						esc_html__( 'JWT Authentication Error', 'ah-jwt-auth' ), 
-						array( 'response' => 401 ) 
+					wp_die(
+						esc_html__( 'Authentication failed: No account exists for this JWT.', 'ah-jwt-auth' ),
+						esc_html__( 'JWT Authentication Error', 'ah-jwt-auth' ),
+						array( 'response' => 401 )
 					);
 				}
 				
@@ -301,7 +301,7 @@ class AhJwtAuthSignIn {
 		$request_headers = getallheaders();
 		$normalized_headers = array_change_key_case( $request_headers, CASE_LOWER );
 		$target_header = strtolower( get_option( 'ahjwtauth-jwt-header', 'Authorization' ) );
-		
+
 		if ( ! isset( $normalized_headers[ $target_header ] ) ) {
 			$this->warning = __( 'AH JWT Auth: The expected JWT was not found. Please double check your reverse proxy configuration.', 'ah-jwt-auth' );
 			error_log( 'AH JWT Auth: WARNING: The expected JWT was not found.' );

--- a/includes/class-ahjwtauthsignin.php
+++ b/includes/class-ahjwtauthsignin.php
@@ -10,8 +10,16 @@
 
 namespace AhJwtAuth;
 
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+use DomainException;
 use Exception;
+use UnexpectedValueException;
 use Firebase\JWT\JWT;
+use Firebase\JWT\BeforeValidException;
+use Firebase\JWT\ExpiredException;
 use Firebase\JWT\SignatureInvalidException;
 use Firebase\JWT\JWK;
 use Firebase\JWT\Key;
@@ -57,8 +65,8 @@ class AhJwtAuthSignIn {
 
 		add_action( 'admin_notices', array( $this, 'ahjwtauth_admin_notice' ) );
 		add_action( 'login_head', array( $this, 'ahjwtauth_log_user_in' ) );
-		add_action( 'login_head', array( $this, 'ahjwtauth_schedule_refresh_jwks' ) );
-		add_action( 'ahjwtauth_refresh_jwks', array( $this, 'ahjwtauth_refresh_jwks' ) );
+		add_action( 'admin_init', array( $this, 'ahjwtauth_schedule_fetch_jwks' ) );
+		add_action( 'ahjwtauth_fetch_jwks', array( $this, 'ahjwtauth_fetch_jwks' ) );
 	}
 
 	/**
@@ -113,9 +121,12 @@ class AhJwtAuthSignIn {
 			}
 		}
 
-		// If we can extract the user's role from the JWT, then set the role, otherwise leave as-is.
+		// If we can extract the user's role from the JWT and it is valid then set the role, otherwise leave as-is.
 		if ( isset( $payload->role ) ) {
-			$user->set_role( strtolower( $payload->role ) );
+			$role = strtolower( $payload->role );
+			if ( array_key_exists( $role, wp_roles()->get_names() ) ) {
+				$user->set_role( $role );
+			}
 		}
 
 		wp_clear_auth_cookie();
@@ -128,7 +139,8 @@ class AhJwtAuthSignIn {
 		if ( current_user_can( 'manage_options' ) ) {
 			$redirect_url = admin_url();
 		}
-		wp_safe_redirect( isset( $_GET['redirect_to'] ) ? wp_unslash( $_GET['redirect_to'] ) : $redirect_url );
+		$redirect_to = isset( $_GET['redirect_to'] ) ? esc_url_raw( wp_unslash( $_GET['redirect_to'] ) ) : $redirect_url;
+		wp_safe_redirect( $redirect_to );
 		exit;
 	}
 
@@ -154,13 +166,13 @@ class AhJwtAuthSignIn {
 	}
 
 	/**
-	 * Schedules the refresh of the JWKS via WP Cron
+	 * Schedules the fetch of the JWKS via WP Cron
 	 *
 	 * @return void
 	 */
-	public function ahjwtauth_schedule_refresh_jwks() {
-		if ( ! wp_next_scheduled( 'ahjwtauth_refresh_jwks' ) ) {
-			wp_schedule_event( time(), 'daily', 'ahjwtauth_refresh_jwks' );
+	public function ahjwtauth_schedule_fetch_jwks() {
+		if ( ! wp_next_scheduled( 'ahjwtauth_fetch_jwks' ) ) {
+			wp_schedule_event( time(), 'daily', 'ahjwtauth_fetch_jwks' );
 		}
 	}
 
@@ -171,7 +183,7 @@ class AhJwtAuthSignIn {
 	 *
 	 * @return array an associative array containing the key set
 	 */
-	public function ahjwtauth_refresh_jwks() {
+	public function ahjwtauth_fetch_jwks() {
 		$jwks_url = get_option( 'ahjwtauth-jwks-url' );
 		if ( '' === $jwks_url ) {
 			return true;
@@ -243,9 +255,9 @@ class AhJwtAuthSignIn {
 			return false;
 		}
 
-		// Handle "Header: Bearer <JWT>" form by stipping the "Bearer " prefix.
-		$array = explode( ' ', sanitize_text_field( wp_unslash( $_SERVER[ $jwt_header ] ) ) );
-		if ( 'Bearer' == $array[0] ) {
+		// Handle "Header: Bearer <JWT>" form by stripping the "Bearer " prefix.
+		$array = explode( ' ', wp_unslash( $_SERVER[ $jwt_header ] ) );
+		if ( 'Bearer' === $array[0] ) {
 			array_shift( $array );
 		}
 
@@ -290,8 +302,8 @@ class AhJwtAuthSignIn {
 			error_log( 'AH JWT Auth: ERROR: The provided JWT has since expired, as defined by the \'exp\' claim: ' . $e->getMessage() );
 			return false;
 		} catch ( Exception $e ) {
-			$this->error = __( 'AH JWT Auth: There was an unhandled exception while verifiying the JWT', 'ah-jwt-auth' );
-			error_log( 'AH JWT Auth: ERROR: There was an unhandled exception while verifiying the JWT: ' . $e->getMessage() );
+			$this->error = __( 'AH JWT Auth: There was an unhandled exception while verifying the JWT', 'ah-jwt-auth' );
+			error_log( 'AH JWT Auth: ERROR: There was an unhandled exception while verifying the JWT: ' . $e->getMessage() );
 			return false;
 		}
 		if ( ! $this->validate_audience( $payload ) || ! $this->validate_issuer( $payload ) ) {
@@ -381,14 +393,13 @@ class AhJwtAuthSignIn {
 	private function get_key() {
 		$jwks_url = get_option( 'ahjwtauth-jwks-url' );
 		if ( '' !== $jwks_url ) {
-			$jwks = $this->ahjwtauth_refresh_jwks();
+			$jwks = $this->ahjwtauth_fetch_jwks();
 
 			try {
 				$keys = JWK::parseKeySet( array( 'keys' => $jwks['keys'] ) );
 			} catch ( Exception $e ) {
 				$this->error = $e->getMessage();
 				error_log( 'AH JWT Auth: ERROR: Problem parsing key-set: ' . $e->getMessage() );
-				error_log( $json );
 				return false;
 			}
 

--- a/includes/class-ahjwtauthsignin.php
+++ b/includes/class-ahjwtauthsignin.php
@@ -119,7 +119,7 @@ class AhJwtAuthSignIn {
 					array( 'response' => 401 )
 				);
 			}
-			
+
 			return;
 		}
 
@@ -133,7 +133,7 @@ class AhJwtAuthSignIn {
 					array( 'response' => 401 )
 				);
 			}
-			
+
 			$this->error = __( 'AH JWT Auth expects email attribute to identify user, but it does not exist in the JWT. Please check your reverse proxy configuration', 'ah-jwt-auth' );
 			return;
 		}
@@ -151,7 +151,7 @@ class AhJwtAuthSignIn {
 						array( 'response' => 401 )
 					);
 				}
-				
+
 				$this->error = __( 'AH JWT Auth found a valid JWT, but the user does not exist and automatic user creation is disabled.', 'ah-jwt-auth' );
 				error_log( 'AH JWT Auth: ERROR: valid JWT found, but user does not exist and automatic user creation is disabled.' );
 				return;

--- a/readme.txt
+++ b/readme.txt
@@ -71,9 +71,9 @@ The `aud` and `iss` claims are only required when a JWT Audience and/or Issuer
 value has been configured in the plugin settings, however as they are standard
 JWT claims it is recommended to set these options to verify those claims.
 
-= What signature algorimths are supported to verify the JWT? =
+= What signature algorithms are supported to verify the JWT? =
 
-Currently only the HS256 and RS256 alorithms are supported.
+Currently only the HS256 and RS256 algorithms are supported.
 
 == Screenshots ==
 
@@ -86,7 +86,7 @@ Currently only the HS256 and RS256 alorithms are supported.
 * Add option to verify JWT issuer
 
 = 2.0.0 =
-* **Breaking Change:** Any secrets that are less than 256-bytes (32-characters)
+* **Breaking Change:** Any secrets that are less than 256-bits (32-characters)
   in length will fail JWT HS256 verification
 
 = 1.6.0 =

--- a/readme.txt
+++ b/readme.txt
@@ -82,6 +82,11 @@ Currently only the HS256 and RS256 algorithms are supported.
 
 == Changelog ==
 
+= 2.2.0 =
+* Fixing of spelling and hardening
+* Add option to enforce JWT auth (ie "fail-closed") rather than falling
+  through to WordPress authentication.
+
 = 2.1.0 =
 * Add option to verify JWT issuer
 

--- a/templates/options-form.php
+++ b/templates/options-form.php
@@ -7,9 +7,13 @@
  * @package AhJwtAuth
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
 ?>
 <div class="wrap">
-	<h1>AH JWT Auth</h1>
+	<h1><?php echo esc_html__( 'AH JWT Auth', 'ah-jwt-auth' ); ?></h1>
 
 	<form method="post" action="options.php">
 		<?php settings_fields( 'ahjwtauth-sign-in-widget' ); ?>

--- a/templates/options-form.php
+++ b/templates/options-form.php
@@ -8,7 +8,7 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 ?>


### PR DESCRIPTION
This PR is based on a code review by both Claude and Gemini with the addition of a new option to "fail-closed" where a missing or invalid JWT will explicitly deny access rather than falling (which is the default behaviour).  